### PR TITLE
Remove old node versions from travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,3 @@ script:
   - npm test
 node_js:
   - "node"
-  - "6"
-  - "4"


### PR DESCRIPTION
Node v4 and v6 are EOL since 2018, and as such should not be used anymore.