### PR TITLE
Code cleanup, Switch to assert in tests, and HTTP Agent/Proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/*
 npm-debug.log
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 npm-debug.log
 package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ However, the folks over at [PrismarineJS](https://github.com/PrismarineJS/) have
 ## Client
 ```js
 //init
-var ygg = require('yggdrasil')({
+const ygg = require('yggdrasil')({
   //Optional settings object
   host: 'https://authserver.mojang.com' //Optional custom host. No trailing slash.
 });
@@ -40,7 +40,7 @@ ygg.signout(username, password, function(err));
 
 ## Server
 ```js
-var yggserver = require('yggdrasil').server({
+const yggserver = require('yggdrasil').server({
   //Optional settings object
   host: 'https://authserver.mojang.com' //Optional custom host. No trailing slash.
 });

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ yggserver.join(token, profile, serverid, sharedsecret, serverkey, function(err, 
 //Join a server (serverside)
 yggserver.hasJoined(username, serverid, sharedsecret, serverkey, function(err, client info){});
 ```
+## Proxy Support
+```js
+const proxyAgent = require('proxy-agent');
+
+const ygg = require('yggdrasil')({
+  //Any type of HTTP Agent 
+  agent: new proxyAgent('https://example.com:8080')
+});
+```
 
 ## With ES6 Named Exports
 ```js

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ yggserver.hasJoined(username, serverid, sharedsecret, serverkey, function(err, c
 ```
 ## Proxy Support
 ```js
-const proxyAgent = require('proxy-agent');
+const ProxyAgent = require('proxy-agent');
 
 const ygg = require('yggdrasil')({
   //Any type of HTTP Agent 
-  agent: new proxyAgent('https://example.com:8080')
+  agent: new ProxyAgent('https://example.com:8080')
 });
 ```
 

--- a/es6.js
+++ b/es6.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var Client = require('./lib/Client')
-var Server = require('./lib/Server')
+const Client = require('./lib/Client')
+const Server = require('./lib/Server')
 
 module.exports = { Client, Server }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var uuid = require('uuid')
-var utils = require('./utils')
+const uuid = require('uuid')
+const utils = require('./utils')
 
-var Client = {}
+const Client = {}
 
-var defaultHost = 'https://authserver.mojang.com'
+const defaultHost = 'https://authserver.mojang.com'
 
 /**
  * Attempts to authenticate a user.
@@ -13,7 +13,7 @@ var defaultHost = 'https://authserver.mojang.com'
  * @param  {Function} cb      Callback
  */
 Client.auth = function (options, cb) {
-  var host = this.host || defaultHost
+  const host = this.host || defaultHost
 
   if (options.token === null) {
     delete options.token
@@ -43,7 +43,7 @@ Client.auth = function (options, cb) {
  * @param  {Function} cb     (err, new token, full response body)
  */
 Client.refresh = function (access, client, cb) {
-  var host = this.host || defaultHost
+  const host = this.host || defaultHost
   utils.call(host, 'refresh', {
     accessToken: access,
     clientToken: client
@@ -62,7 +62,7 @@ Client.refresh = function (access, client, cb) {
  * @param  {Function} cb    (error)
  */
 Client.validate = function (token, cb) {
-  var host = this.host || defaultHost
+  const host = this.host || defaultHost
   utils.call(host, 'validate', {
     accessToken: token
   }, function (err, data) {
@@ -77,7 +77,7 @@ Client.validate = function (token, cb) {
  * @param  {Function} cb   (error)
  */
 Client.signout = function (user, pass, cb) {
-  var host = this.host || defaultHost
+  const host = this.host || defaultHost
   utils.call(host, 'signout', {
     username: user,
     password: pass

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -31,9 +31,9 @@ Client.auth = function (options, cb) {
     password: options.pass,
     clientToken: options.token,
     requestUser: options.requestUser === true
-  }, function (err, data) {
+  }, this.agent, function (err, data) {
     cb(err, data)
-  }, this.agent)
+  })
 }
 
 /**
@@ -47,13 +47,13 @@ Client.refresh = function (access, client, cb) {
   utils.call(host, 'refresh', {
     accessToken: access,
     clientToken: client
-  }, function (err, data) {
+  }, this.agent, function (err, data) {
     if (data && data.clientToken !== client) {
       cb(new Error('clientToken assertion failed'))
     } else {
       cb(err, data ? data.accessToken : null, data)
     }
-  }, this.agent)
+  })
 }
 
 /**
@@ -65,9 +65,9 @@ Client.validate = function (token, cb) {
   const host = this.host || defaultHost
   utils.call(host, 'validate', {
     accessToken: token
-  }, function (err, data) {
+  }, this.agent, function (err, data) {
     cb(err)
-  }, this.agent)
+  })
 }
 
 /**
@@ -81,9 +81,9 @@ Client.signout = function (user, pass, cb) {
   utils.call(host, 'signout', {
     username: user,
     password: pass
-  }, function (err, data) {
+  }, this.agent, function (err, data) {
     cb(err)
-  }, this.agent)
+  })
 }
 
 module.exports = Client

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -33,7 +33,7 @@ Client.auth = function (options, cb) {
     requestUser: options.requestUser === true
   }, function (err, data) {
     cb(err, data)
-  })
+  }, this.agent)
 }
 
 /**
@@ -53,7 +53,7 @@ Client.refresh = function (access, client, cb) {
     } else {
       cb(err, data ? data.accessToken : null, data)
     }
-  })
+  }, this.agent)
 }
 
 /**
@@ -67,7 +67,7 @@ Client.validate = function (token, cb) {
     accessToken: token
   }, function (err, data) {
     cb(err)
-  })
+  }, this.agent)
 }
 
 /**
@@ -83,7 +83,7 @@ Client.signout = function (user, pass, cb) {
     password: pass
   }, function (err, data) {
     cb(err)
-  })
+  }, this.agent)
 }
 
 module.exports = Client

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var crypto = require('crypto')
-var utils = require('./utils')
+const crypto = require('crypto')
+const utils = require('./utils')
 
-var Server = {}
+const Server = {}
 
-var defaultHost = 'https://sessionserver.mojang.com'
+const defaultHost = 'https://sessionserver.mojang.com'
 
 /**
  * Client's Mojang handshake call
@@ -19,14 +19,14 @@ var defaultHost = 'https://sessionserver.mojang.com'
  * @async
  */
 Server.join = function (token, profile, serverid, sharedsecret, serverkey, cb) {
-  var host = this.host || defaultHost
+  const host = this.host || defaultHost
   utils.call(host, 'session/minecraft/join', {
     accessToken: token,
     selectedProfile: profile,
     serverId: utils.mcHexDigest(crypto.createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
   }, function (err, data) {
     cb(err, data)
-  })
+  }, this.agent)
 }
 
 /**
@@ -39,11 +39,17 @@ Server.join = function (token, profile, serverid, sharedsecret, serverkey, cb) {
  * @async
  */
 Server.hasJoined = function (username, serverid, sharedsecret, serverkey, cb) {
-  var host = this.host || defaultHost
-  var hash = utils.mcHexDigest(crypto.createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
-  utils.phin(host + '/session/minecraft/hasJoined?username=' + username + '&serverId=' + hash, function (err, resp) {
+  const host = this.host || defaultHost
+  const hash = utils.mcHexDigest(crypto.createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
+  utils.phin({
+    url: host + '/session/minecraft/hasJoined?username=' + username + '&serverId=' + hash,
+    core: {
+      agent: this.agent
+    }
+  }, function (err, resp) {
+    let body
     try {
-      var body = JSON.parse(resp.body.toString())
+      body = JSON.parse(resp.body.toString())
     } catch (caughtErr) {
       err = caughtErr
     }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -24,9 +24,9 @@ Server.join = function (token, profile, serverid, sharedsecret, serverkey, cb) {
     accessToken: token,
     selectedProfile: profile,
     serverId: utils.mcHexDigest(crypto.createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
-  }, function (err, data) {
+  }, this.agent, function (err, data) {
     cb(err, data)
-  }, this.agent)
+  })
 }
 
 /**

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -42,7 +42,7 @@ Server.hasJoined = function (username, serverid, sharedsecret, serverkey, cb) {
   const host = this.host || defaultHost
   const hash = utils.mcHexDigest(crypto.createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
   utils.phin({
-    url: host + '/session/minecraft/hasJoined?username=' + username + '&serverId=' + hash,
+    url: `${host}/session/minecraft/hasJoined?username=${username}&serverId=${hash}`,
     core: {
       agent: this.agent
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,10 @@
  * Shim the library to make the API 100% backwards compatible with the old version.
  */
 
-var Client = require('./Client')
-var Server = require('./Server')
+const Client = require('./Client')
+const Server = require('./Server')
 
-var Yggdrasil = function (options) {
+const Yggdrasil = function (options) {
   return Object.assign({}, Client, options)
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,14 +13,14 @@ utils.phin = phin
 /**
  * Generic POST request
  */
-utils.call = function (host, path, data, cb, agent) {
+utils.call = function (host, path, data, agent, cb) {
   phin({
     method: 'POST',
     url: `${host}/${path}`,
-    data: data,
-    headers: headers,
+    data,
+    headers,
     core: {
-      agent: agent
+      agent
     }
   }, function (err, resp) {
     if (err) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,23 +37,16 @@ utils.call = function (host, path, data, cb) {
         // Probably a cloudflare error page
         const body = resp.body.toString()
 
-        switch (resp.statusCode) {
-          case 403:
-            if (/Request blocked\./.test(body)) {
-              err = new Error('Request blocked by CloudFlare')
-              break
-            }
-
-            if (/cf-error-code">1009/.test(body)) {
-              err = new Error('Yout IP is banned by CloudFlare')
-              break
-            }
-
-            break
-          default:
-            err = new Error('Response is not JSON. Status code: ' + resp.statusCode)
-
-            err.code = resp.statusCode
+        if (resp.statusCode === 403) {
+          if (/Request blocked\./.test(body)) {
+            err = new Error('Request blocked by CloudFlare')
+          }
+          if (/cf-error-code">1009/.test(body)) {
+            err = new Error('Your IP is banned by CloudFlare')
+          }
+        } else {
+          err = new Error('Response is not JSON. Status code: ' + resp.statusCode)
+          err.code = resp.statusCode
         }
       } else {
         err = caughtErr

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -95,7 +95,7 @@ utils.mcHexDigest = function mcHexDigest (hash, encoding) {
   // check for negative hashes
   const negative = hash.readInt8(0) < 0
   if (negative) performTwosCompliment(hash)
-  return negative ? '-' : '' + hash.toString('hex').replace(/^0+/g, '')
+  return (negative ? '-' : '') + hash.toString('hex').replace(/^0+/g, '')
 }
 
 module.exports = utils

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,7 @@ utils.phin = phin
 utils.call = function (host, path, data, cb, agent) {
   phin({
     method: 'POST',
-    url: host + '/' + path,
+    url: `${host}/${path}`,
     data: data,
     headers: headers,
     core: {
@@ -95,11 +95,7 @@ utils.mcHexDigest = function mcHexDigest (hash, encoding) {
   // check for negative hashes
   const negative = hash.readInt8(0) < 0
   if (negative) performTwosCompliment(hash)
-  let digest = hash.toString('hex')
-  // trim leading zeroes
-  digest = digest.replace(/^0+/g, '')
-  if (negative) digest = '-' + digest
-  return digest
+  return negative ? '-' : '' + hash.toString('hex').replace(/^0+/g, '')
 }
 
 module.exports = utils

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,12 +1,12 @@
-var version = require('../package.json').version
-var phin = require('phin')
+const version = require('../package.json').version
+const phin = require('phin').unpromisified
 
-var headers = {
+const headers = {
   'User-Agent': 'node-yggdrasil/' + version,
   'Content-Type': 'application/json'
 }
 
-var utils = {}
+const utils = {}
 
 utils.phin = phin
 
@@ -29,9 +29,9 @@ utils.call = function (host, path, data, cb) {
       cb(null, '')
       return
     }
-
+    let body
     try {
-      var body = JSON.parse(resp.body)
+      body = JSON.parse(resp.body)
     } catch (caughtErr) {
       if (caughtErr instanceof SyntaxError) {
         // Probably a cloudflare error page
@@ -74,8 +74,8 @@ utils.call = function (host, path, data, cb) {
  * https://gist.github.com/andrewrk/4425843
  */
 function performTwosCompliment (buffer) {
-  var carry = true
-  var i, newByte, value
+  let carry = true
+  let i, newByte, value
   for (i = buffer.length - 1; i >= 0; --i) {
     value = buffer.readUInt8(i)
     newByte = ~value & 0xff
@@ -97,9 +97,9 @@ function performTwosCompliment (buffer) {
 utils.mcHexDigest = function mcHexDigest (hash, encoding) {
   if (!(hash instanceof Buffer)) { hash = Buffer.from(hash, encoding) }
   // check for negative hashes
-  var negative = hash.readInt8(0) < 0
+  const negative = hash.readInt8(0) < 0
   if (negative) performTwosCompliment(hash)
-  var digest = hash.toString('hex')
+  let digest = hash.toString('hex')
   // trim leading zeroes
   digest = digest.replace(/^0+/g, '')
   if (negative) digest = '-' + digest

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,12 +13,15 @@ utils.phin = phin
 /**
  * Generic POST request
  */
-utils.call = function (host, path, data, cb) {
+utils.call = function (host, path, data, cb, agent) {
   phin({
     method: 'POST',
     url: host + '/' + path,
     data: data,
-    headers: headers
+    headers: headers,
+    core: {
+      agent: agent
+    }
   }, function (err, resp) {
     if (err) {
       cb(err)

--- a/package.json
+++ b/package.json
@@ -21,14 +21,13 @@
     "authentication"
   ],
   "dependencies": {
-    "phin": "^2.2.1",
-    "uuid": "^3.1.0"
+    "phin": "^3.4.1",
+    "uuid": "^3.4.0"
   },
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^3.5.0",
-    "nock": "^9.0.14",
-    "should": "^11.2.1",
+    "mocha": "^7.0.1",
+    "nock": "^11.7.2",
     "standard": "^14.3.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ describe('utils', function () {
 
       uscope.post('/test', {}).reply(200, bsdata)
       utils.call(google, 'test', {}, function (err, data) {
-        assert.strictEqual(err, null)
+        assert.ifError(err)
         assert.deepStrictEqual(data, bsdata)
         done()
       })
@@ -132,7 +132,7 @@ describe('Yggdrasil', function () {
         clientToken: 'not bacon'
       })
       ygg.refresh('bacon', 'not bacon', function (err, token) {
-        assert.strictEqual(err, null)
+        assert.ifError(err)
         assert.strictEqual(token, 'different bacon')
         done()
       })
@@ -159,7 +159,7 @@ describe('Yggdrasil', function () {
         accessToken: 'a magical key'
       }).reply(200)
       ygg.validate('a magical key', function (err) {
-        assert.strictEqual(err, null)
+        assert.ifError(err)
         done()
       })
     })

--- a/test/index.js
+++ b/test/index.js
@@ -1,27 +1,27 @@
 /* eslint-env mocha */
 'use strict'
 
-var crypto = require('crypto')
-var should = require('should')
-var nock = require('nock')
+const crypto = require('crypto')
+const assert = require('assert')
+const nock = require('nock')
 
-var utils = require('../lib/utils')
+const utils = require('../lib/utils')
 
 describe('utils', function () {
   describe('call', function () {
-    var google = 'https://google.com'
-    var uscope = nock(google)
+    const google = 'https://google.com'
+    const uscope = nock(google)
 
     it('should work when given valid data', function (done) {
-      var bsdata = {
+      const bsdata = {
         cake: true,
         username: 'someone'
       }
 
       uscope.post('/test', {}).reply(200, bsdata)
       utils.call(google, 'test', {}, function (err, data) {
-        should(err).be.null()
-        data.should.eql(bsdata)
+        assert.notStrictEqual(err, undefined)
+        assert.deepStrictEqual(data, bsdata)
         done()
       })
     })
@@ -32,9 +32,9 @@ describe('utils', function () {
         errorMessage: 'Yep, you failed.'
       })
       utils.call(google, 'test2', {}, function (err, data) {
-        should(data).be.undefined()
-        err.should.be.an.instanceOf(Error)
-        err.message.should.equal('Yep, you failed.')
+        assert.strictEqual(data, undefined)
+        assert.ok(err instanceof Error)
+        assert.strictEqual(err.message, 'Yep, you failed.')
         done()
       })
     })
@@ -48,7 +48,7 @@ describe('utils', function () {
   describe('mcHexDigest', function () {
     it('should work against test data', function () {
       // circa http://wiki.vg/Protocol_Encryption#Client
-      var testdata = {
+      const testdata = {
         Notch: '4ed1f46bbe04bc756bcb17c0c7ce3e4632f06a48',
         jeb_: '-7c9d5b0044c130109a5d7b5fb5c317c02b4e28c1',
         simon: '88e16a1019277b15d58faf0541e11910eb756f6',
@@ -56,19 +56,19 @@ describe('utils', function () {
       }
 
       Object.keys(testdata).forEach(function (name) {
-        var hash = crypto.createHash('sha1').update(name).digest()
-        utils.mcHexDigest(hash).should.equal(testdata[name])
+        const hash = crypto.createHash('sha1').update(name).digest()
+        assert.strictEqual(utils.mcHexDigest(hash), testdata[name])
       })
     })
 
     it('should handle negative hashes ending with a zero byte without crashing', function () {
-      utils.mcHexDigest(Buffer.from([-1, 0])).should.equal('-100')
+      assert.strictEqual(utils.mcHexDigest(Buffer.from([-1, 0])), '-100')
     })
   })
 })
 
-var cscope = nock('https://authserver.mojang.com')
-var ygg = require('../lib/index')({})
+const cscope = nock('https://authserver.mojang.com')
+const ygg = require('../lib/index')({})
 
 describe('Yggdrasil', function () {
   describe('auth', function () {
@@ -90,7 +90,7 @@ describe('Yggdrasil', function () {
         pass: 'hunter2',
         token: 'bacon'
       }, function (err, data) { // eslint-disable-line handle-callback-err
-        data.should.eql({
+        assert.deepStrictEqual(data, {
           worked: true
         })
         done()
@@ -115,7 +115,7 @@ describe('Yggdrasil', function () {
         token: 'bacon',
         requestUser: true
       }, function (err, data) { // eslint-disable-line handle-callback-err
-        data.should.eql({
+        assert.deepStrictEqual(data, {
           worked: true
         })
         done()
@@ -132,8 +132,8 @@ describe('Yggdrasil', function () {
         clientToken: 'not bacon'
       })
       ygg.refresh('bacon', 'not bacon', function (err, token) {
-        should(err).be.null()
-        token.should.equal('different bacon')
+        assert.notStrictEqual(err, undefined)
+        assert.strictEqual(token, 'different bacon')
         done()
       })
     })
@@ -146,9 +146,9 @@ describe('Yggdrasil', function () {
         clientToken: 'bacon'
       })
       ygg.refresh('bacon', 'not bacon', function (err, token) {
-        should(token).be.undefined()
-        err.should.be.an.instanceOf(Error)
-        err.message.should.equal('clientToken assertion failed')
+        assert.notStrictEqual(err, undefined)
+        assert.ok(err instanceof Error)
+        assert.strictEqual(err.message, 'clientToken assertion failed')
         done()
       })
     })
@@ -159,7 +159,7 @@ describe('Yggdrasil', function () {
         accessToken: 'a magical key'
       }).reply(200)
       ygg.validate('a magical key', function (err) {
-        should(err).be.null()
+        assert.notStrictEqual(err, undefined)
         done()
       })
     })
@@ -171,8 +171,8 @@ describe('Yggdrasil', function () {
         errorMessage: 'User is an egg'
       })
       ygg.validate('a magical key', function (err) {
-        err.should.be.an.instanceOf(Error)
-        err.message.should.equal('User is an egg')
+        assert.ok(err instanceof Error)
+        assert.strictEqual(err.message, 'User is an egg')
         done()
       })
     })
@@ -182,8 +182,8 @@ describe('Yggdrasil', function () {
   })
 })
 
-var sscope = nock('https://sessionserver.mojang.com')
-var yggserver = require('../lib/index').server({})
+const sscope = nock('https://sessionserver.mojang.com')
+const yggserver = require('../lib/index').server({})
 
 describe('Yggdrasil.server', function () {
   describe('join', function () {
@@ -197,7 +197,7 @@ describe('Yggdrasil.server', function () {
       })
 
       yggserver.join('anAccessToken', 'aSelectedProfile', 'cat', 'cat', 'cat', function (err, data) { // eslint-disable-line handle-callback-err
-        data.should.eql({
+        assert.deepStrictEqual(data, {
           worked: true
         })
         done()
@@ -214,7 +214,7 @@ describe('Yggdrasil.server', function () {
 
       yggserver.hasJoined('ausername', 'cat', 'cat', 'cat', function (err, data) {
         if (err) return done(err)
-        data.should.eql({
+        assert.deepStrictEqual(data, {
           id: 'cat',
           worked: true
         })
@@ -225,7 +225,7 @@ describe('Yggdrasil.server', function () {
       sscope.get('/session/minecraft/hasJoined?username=ausername&serverId=-af59e5b1d5d92e5c2c2776ed0e65e90be181f2a').reply(200)
 
       yggserver.hasJoined('ausername', 'cat', 'cat', 'cat', function (err, data) {
-        err.should.be.an.instanceOf(Error)
+        assert.ok(err instanceof Error)
         done()
       })
     })

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ describe('utils', function () {
       }
 
       uscope.post('/test', {}).reply(200, bsdata)
-      utils.call(google, 'test', {}, function (err, data) {
+      utils.call(google, 'test', {}, undefined, function (err, data) {
         assert.ifError(err)
         assert.deepStrictEqual(data, bsdata)
         done()
@@ -31,7 +31,7 @@ describe('utils', function () {
         error: 'ThisBeAError',
         errorMessage: 'Yep, you failed.'
       })
-      utils.call(google, 'test2', {}, function (err, data) {
+      utils.call(google, 'test2', {}, undefined, function (err, data) {
         assert.strictEqual(data, undefined)
         assert.ok(err instanceof Error)
         assert.strictEqual(err.message, 'Yep, you failed.')

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ describe('utils', function () {
 
       uscope.post('/test', {}).reply(200, bsdata)
       utils.call(google, 'test', {}, function (err, data) {
-        assert.notStrictEqual(err, undefined)
+        assert.strictEqual(err, null)
         assert.deepStrictEqual(data, bsdata)
         done()
       })
@@ -132,7 +132,7 @@ describe('Yggdrasil', function () {
         clientToken: 'not bacon'
       })
       ygg.refresh('bacon', 'not bacon', function (err, token) {
-        assert.notStrictEqual(err, undefined)
+        assert.strictEqual(err, null)
         assert.strictEqual(token, 'different bacon')
         done()
       })
@@ -146,7 +146,7 @@ describe('Yggdrasil', function () {
         clientToken: 'bacon'
       })
       ygg.refresh('bacon', 'not bacon', function (err, token) {
-        assert.notStrictEqual(err, undefined)
+        assert.notStrictEqual(err, null)
         assert.ok(err instanceof Error)
         assert.strictEqual(err.message, 'clientToken assertion failed')
         done()
@@ -159,7 +159,7 @@ describe('Yggdrasil', function () {
         accessToken: 'a magical key'
       }).reply(200)
       ygg.validate('a magical key', function (err) {
-        assert.notStrictEqual(err, undefined)
+        assert.strictEqual(err, null)
         done()
       })
     })


### PR DESCRIPTION
ES6 variable syntax, assert instead of should, http agent support for proxy support, and general cleanup
Do to Phin only supporting http agent(and as such proxies as well) since version 3.3.0 i had to update it. (I updated the other packages as well as they didnt have any breaking changes and their current versions had multiple known critical vulnerabilities)
closes #35
and closes PrismarineJS/node-minecraft-protocol#481