### PR TITLE
Add ability to request user from token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ ygg.auth({
   agent: '', //Agent name. Defaults to 'Minecraft'
   version: 1, //Agent version. Defaults to 1
   user: '', //Username
-  pass: '' //Password
+  pass: '', //Password
+  requestUser: false //Optional. Request the user object to be included in response
 }, function(err, data){});
 
 //Refresh an accessToken
-ygg.refresh(oldtoken, clienttoken, function(err, newtoken, response body){});
+ygg.refresh(oldtoken, clienttoken, requestUser: false, function(err, newtoken, response body){});
+// Note that requestUser is an optional parameter. If set to true, it requests the user object from Mojang's authentication servers as well.
 
 //Validate an accessToken
 ygg.validate(token, function(err){});

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ygg.auth({
 }, function(err, data){});
 
 //Refresh an accessToken
-ygg.refresh(oldtoken, clienttoken, requestUser: false, function(err, newtoken, response body){});
+ygg.refresh(oldtoken, clienttoken, true, function(err, newtoken, response body){});
 // Note that requestUser is an optional parameter. If set to true, it requests the user object from Mojang's authentication servers as well.
 
 //Validate an accessToken

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -40,9 +40,14 @@ Client.auth = function (options, cb) {
  * Refreshes a accessToken.
  * @param  {String}   access Old Access Token
  * @param  {String}   client Client Token
+ * @param  {String=false}   requestUser Whether to request the user object
  * @param  {Function} cb     (err, new token, full response body)
  */
-Client.refresh = function (access, client, cb, requestUser) {
+Client.refresh = function (access, client, requestUser, cb) {
+  if (typeof requestUser === 'function') {
+    cb = requestUser
+    requestUser = false
+  }
   const host = this.host || defaultHost
   utils.call(host, 'refresh', {
     accessToken: access,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -42,11 +42,12 @@ Client.auth = function (options, cb) {
  * @param  {String}   client Client Token
  * @param  {Function} cb     (err, new token, full response body)
  */
-Client.refresh = function (access, client, cb) {
+Client.refresh = function (access, client, cb, requestUser) {
   const host = this.host || defaultHost
   utils.call(host, 'refresh', {
     accessToken: access,
-    clientToken: client
+    clientToken: client,
+    requestUser: !!requestUser
   }, this.agent, function (err, data) {
     if (data && data.clientToken !== client) {
       cb(new Error('clientToken assertion failed'))

--- a/test/index.js
+++ b/test/index.js
@@ -159,14 +159,14 @@ describe('Yggdrasil', function () {
           properties: []
         }
       })
-      ygg.refresh('bacon', 'not bacon', function (err, token, data) {
+      ygg.refresh('bacon', 'not bacon', true, function (err, token, data) {
         assert.ifError(err)
         assert.strictEqual(token, 'different bacon')
         assert.ok(data.user)
         assert.ok(data.user.properties)
         assert.strictEqual(data.user.id, '4ed1f46bbe04bc756bcb17c0c7ce3e4632f06a48')
         done()
-      }, true)
+      })
     })
     it('should error on invalid clientToken', function (done) {
       cscope.post('/refresh', {

--- a/test/index.js
+++ b/test/index.js
@@ -134,7 +134,8 @@ describe('Yggdrasil', function () {
     it('should work correctly', function (done) {
       cscope.post('/refresh', {
         accessToken: 'bacon',
-        clientToken: 'not bacon'
+        clientToken: 'not bacon',
+        requestUser: false
       }).reply(200, {
         accessToken: 'different bacon',
         clientToken: 'not bacon'
@@ -145,10 +146,33 @@ describe('Yggdrasil', function () {
         done()
       })
     })
+    it('should work correctly with requestUser true', function (done) {
+      cscope.post('/refresh', {
+        accessToken: 'bacon',
+        clientToken: 'not bacon',
+        requestUser: true
+      }).reply(200, {
+        accessToken: 'different bacon',
+        clientToken: 'not bacon',
+        user: {
+          id: '4ed1f46bbe04bc756bcb17c0c7ce3e4632f06a48',
+          properties: []
+        }
+      })
+      ygg.refresh('bacon', 'not bacon', function (err, token, data) {
+        assert.ifError(err)
+        assert.strictEqual(token, 'different bacon')
+        assert.ok(data.user)
+        assert.ok(data.user.properties)
+        assert.strictEqual(data.user.id, '4ed1f46bbe04bc756bcb17c0c7ce3e4632f06a48')
+        done()
+      }, true)
+    })
     it('should error on invalid clientToken', function (done) {
       cscope.post('/refresh', {
         accessToken: 'bacon',
-        clientToken: 'not bacon'
+        clientToken: 'not bacon',
+        requestUser: false
       }).reply(200, {
         accessToken: 'different bacon',
         clientToken: 'bacon'


### PR DESCRIPTION
This is needed to be able to refresh profile information into a launcher_profiles.json, something for which I will make a PR soon in node-minecraft-protocol