### PR TITLE
Adding Invalidate Endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yggdrasil",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "Zeke Sonxx <zeke@zekesonxx.com>",
   "description": "Mojang authentication (Yggdrasil) client",
   "scripts": {

--- a/src/Client.js
+++ b/src/Client.js
@@ -3,13 +3,13 @@ const utils = require('./utils')
 
 const defaultHost = 'https://authserver.mojang.com'
 
-function loader (moduleOptions) {
+function loader(moduleOptions) {
   /**
    * Attempts to authenticate a user.
    * @param  {Object}   options Config object
    * @param  {Function} cb      Callback
    */
-  async function auth (options) {
+  async function auth(options) {
     if (options.token === null) delete options.token
     else options.token = options.token ?? uuid.v4()
 
@@ -39,7 +39,7 @@ function loader (moduleOptions) {
    * @param  {Function} cb     (err, new token, full response body)
    */
 
-  async function refresh (accessToken, clientToken, requestUser) {
+  async function refresh(accessToken, clientToken, requestUser) {
     const data = await utils.call(moduleOptions?.host ?? defaultHost, 'refresh', { accessToken, clientToken, requestUser: requestUser ?? false },
       moduleOptions?.agent)
     if (data.clientToken !== clientToken) throw new Error('clientToken assertion failed')
@@ -50,7 +50,7 @@ function loader (moduleOptions) {
    * @param  {String}   accessToken Token to validate
    * @param  {Function} cb    (error)
    */
-  async function validate (accessToken) {
+  async function validate(accessToken) {
     return await utils.call(moduleOptions?.host ?? defaultHost, 'validate', { accessToken }, moduleOptions?.agent)
   }
 
@@ -60,14 +60,24 @@ function loader (moduleOptions) {
    * @param  {String}   password User's pass
    * @param  {Function} cb   (error)
    */
-  async function signout (username, password) {
+  async function signout(username, password) {
     return await utils.call(moduleOptions?.host ?? defaultHost, 'signout', { username, password }, moduleOptions?.agent)
+  }
+
+  /**
+   * Invalidates all access tokens using client/access token pair.
+   * @param  {String}   clientToken Client Token
+   * @param  {String}   accessToken Access Token
+   */
+  async function invalidate(accessToken, clientToken) {
+    return await utils.call(moduleOptions?.host ?? defaultHost, 'invalidate', { accessToken, clientToken }, moduleOptions?.agent)
   }
   return {
     auth: utils.callbackify(auth, 1),
     refresh: utils.callbackify(refresh, 3),
     signout: utils.callbackify(signout, 1),
-    validate: utils.callbackify(validate, 2)
+    validate: utils.callbackify(validate, 2),
+    invalidate: utils.callbackify(invalidate, 2)
   }
 }
 


### PR DESCRIPTION
This PR is for adding the `/invalidate` endpoint to the API as per the [documentation](https://wiki.vg/Authentication#Invalidate).

In order for this to work, you will have to include the following to the body of the request.
```
{
    "accessToken": "valid accessToken",
    "clientToken": "client identifier"   // This needs to be identical to the one used
                                         // to obtain the accessToken in the first place
}
```