### PR TITLE
Fixed "call" function throwing an empty error message

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ async function call (host, path, data, agent) {
       throw e
     }
   }
-  if (body?.error !== undefined) throw new Error(`${body?.error} (status: ${resp.status})`)
+  if (body?.error !== undefined) throw new Error(body?.errorMessage ?? body?.error)
   return body
 }
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ async function call (host, path, data, agent) {
       throw e
     }
   }
-  if (body?.error !== undefined) throw new Error(body?.errorMessage)
+  if (body?.error !== undefined) throw new Error(`${body?.error} (status: ${resp.status})`)
   return body
 }
 /**


### PR DESCRIPTION
Noticed that the error message thrown for invalid requests isn't checked properly.
Simple one line fix for that, squash merge please though haha