### PR TITLE
Implement optional check that user's login ip matches authentication ip

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ## History
 
+## 1.7.1
+* Add optional field ip to yggserver#hasJoined to allow for optionally checking if user's login ip matches with ip authenticated through Mojang's servers
+
 ## 1.7.0
 * Add new endpoint to invalidate all accessTokens using current valid accessToken and clientToken
 * Fixed "call" function throwing an empty error message

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ yggserver.join(token, profile, serverid, sharedsecret, serverkey).then(
 );
 
 //Join a server (serverside)
+// Ip is optional
 yggserver.hasJoined(username, serverid, sharedsecret, serverkey, ip).then(
   (clientInfo)=>{},
   (error)=>{}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ yggserver.join(token, profile, serverid, sharedsecret, serverkey).then(
 );
 
 //Join a server (serverside)
-yggserver.hasJoined(username, serverid, sharedsecret, serverkey).then(
+yggserver.hasJoined(username, serverid, sharedsecret, serverkey, ip).then(
   (clientInfo)=>{},
   (error)=>{}
 );

--- a/src/Server.js
+++ b/src/Server.js
@@ -37,12 +37,13 @@ function loader (moduleOptions) {
    * @param  {String}   sharedsecret Server's secret string
    * @param  {String}   serverkey    Server's encoded public key
    * @param  {Function} cb           (is okay, client info)
+   * @param  {String}   ip           (optional) The ip field is optional and when present should be the IP address of the connecting player; checks ip against authentication server
    * @async
    */
-  async function hasJoined (username, serverid, sharedsecret, serverkey) {
+  async function hasJoined (username, serverid, sharedsecret, serverkey, ip) {
     const host = moduleOptions?.host ?? defaultHost
     const hash = utils.mcHexDigest(createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
-    const data = await nf(`${host}/session/minecraft/hasJoined?username=${encodeURIComponent(username)}&serverId=${hash}`, { agent: moduleOptions?.agent, method: 'GET' })
+    const data = await nf(`${host}/session/minecraft/hasJoined?username=${encodeURIComponent(username)}&serverId=${hash}${ip ? `&ip=${ip}` : ''}`, { agent: moduleOptions?.agent, method: 'GET' })
     const body = JSON.parse(await data.text())
     if (body.id !== undefined) return body
     else throw new Error('Failed to verify username!')

--- a/src/Server.js
+++ b/src/Server.js
@@ -43,7 +43,7 @@ function loader (moduleOptions) {
   async function hasJoined (username, serverid, sharedsecret, serverkey, ip) {
     const host = moduleOptions?.host ?? defaultHost
     const hash = utils.mcHexDigest(createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
-    const data = await nf(`${host}/session/minecraft/hasJoined?username=${encodeURIComponent(username)}&serverId=${hash}${ip ? `&ip=${ip}` : ''}`, { agent: moduleOptions?.agent, method: 'GET' })
+    const data = await nf(`${host}/session/minecraft/hasJoined?username=${encodeURIComponent(username)}&serverId=${hash}${ip ? `&ip=${encodeURIComponent(ip)}` : ''}`, { agent: moduleOptions?.agent, method: 'GET' })
     const body = JSON.parse(await data.text())
     if (body.id !== undefined) return body
     else throw new Error('Failed to verify username!')

--- a/src/Server.js
+++ b/src/Server.js
@@ -36,8 +36,8 @@ function loader (moduleOptions) {
    * @param  {String}   serverid     ASCII encoding of the server ID
    * @param  {String}   sharedsecret Server's secret string
    * @param  {String}   serverkey    Server's encoded public key
-   * @param  {Function} cb           (is okay, client info)
    * @param  {String}   ip           (optional) The ip field is optional and when present should be the IP address of the connecting player; checks ip against authentication server
+   * @param  {Function} cb           (is okay, client info)
    * @async
    */
   async function hasJoined (username, serverid, sharedsecret, serverkey, ip) {
@@ -51,7 +51,7 @@ function loader (moduleOptions) {
 
   return {
     join: utils.callbackify(join, 5),
-    hasJoined: utils.callbackify(hasJoined, 4)
+    hasJoined: utils.callbackify(hasJoined, 5)
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -382,7 +382,7 @@ describe('Yggdrasil.server', () => {
         worked: true
       })
 
-      yggserver.hasJoined('ausername', 'cat', 'cat', 'cat', (err, data) => {
+      yggserver.hasJoined('ausername', 'cat', 'cat', 'cat', null, (err, data) => {
         if (err) return done(err)
         assert.deepStrictEqual(data, {
           id: 'cat',
@@ -406,7 +406,7 @@ describe('Yggdrasil.server', () => {
     it('should fail on a 200 empty response', done => {
       sscope.get('/session/minecraft/hasJoined?username=ausername&serverId=-af59e5b1d5d92e5c2c2776ed0e65e90be181f2a').reply(200)
 
-      yggserver.hasJoined('ausername', 'cat', 'cat', 'cat', (err, data) => {
+      yggserver.hasJoined('ausername', 'cat', 'cat', 'cat', null, (err, data) => {
         assert.ok(err instanceof Error)
         done()
       })

--- a/test/index.js
+++ b/test/index.js
@@ -419,6 +419,14 @@ describe('Yggdrasil.server', () => {
         assert.ok(e instanceof Error)
       }
     })
+    it('should optionally add ip check', done => {
+      sscope.get('/session/minecraft/hasJoined?username=ausername&serverId=-af59e5b1d5d92e5c2c2776ed0e65e90be181f2a&ip=test').reply(200)
+
+      yggserver.hasJoined('ausername', 'cat', 'cat', 'cat', 'test', (err, data) => {
+        assert.ok(err instanceof Error)
+        done()
+      })
+    })
   })
   afterEach(() => {
     sscope.done()


### PR DESCRIPTION
Currently, this project does not implement ip param of hasJoin.

Without it, projects usingg this library for authentication is vulnerable to Alt Dispenser services on join. This allows for low-cost alting attacks against a given server instance.

To mitigate this issue, this change optionally allows checking the ip of the user on log in matches the ip of user on authenticating with Mojang.

Based on the entry here: https://wiki.vg/Protocol_Encryption#Server

Note: change is backwards compatible but should be propagated to [downstream implementations](https://github.com/PrismarineJS/node-minecraft-protocol/blob/78f038cae665e04c7f80feecf2da6a05ad91792e/src/server/login.js#L78) once merged